### PR TITLE
Remain only InputModelTF constructor with GraphIterator and adopt other code

### DIFF
--- a/ngraph/frontend/tensorflow/include/tensorflow_frontend/frontend.hpp
+++ b/ngraph/frontend/tensorflow/include/tensorflow_frontend/frontend.hpp
@@ -57,10 +57,10 @@ protected:
 
 private:
     static void translate_graph(const std::shared_ptr<InputModelTF>& model,
-                         const std::string model_name,
-                         bool fail_fast,
-                         bool no_conversion,
-                         std::shared_ptr<ngraph::Function>& ng_function);
+                                const std::string model_name,
+                                bool fail_fast,
+                                bool no_conversion,
+                                std::shared_ptr<ngraph::Function>& ng_function);
 };
 
 }  // namespace frontend

--- a/ngraph/frontend/tensorflow/include/tensorflow_frontend/frontend.hpp
+++ b/ngraph/frontend/tensorflow/include/tensorflow_frontend/frontend.hpp
@@ -9,8 +9,6 @@
 #include <tensorflow_frontend/model.hpp>
 #include <tensorflow_frontend/utility.hpp>
 
-using namespace ::ngraph::frontend;
-
 namespace ngraph {
 namespace frontend {
 class TF_API FrontEndTF : public FrontEnd {
@@ -57,7 +55,7 @@ protected:
 
 private:
     static void translate_graph(const std::shared_ptr<InputModelTF>& model,
-                                const std::string model_name,
+                                const std::string& model_name,
                                 bool fail_fast,
                                 bool no_conversion,
                                 std::shared_ptr<ngraph::Function>& ng_function);

--- a/ngraph/frontend/tensorflow/include/tensorflow_frontend/frontend.hpp
+++ b/ngraph/frontend/tensorflow/include/tensorflow_frontend/frontend.hpp
@@ -5,18 +5,11 @@
 #pragma once
 
 #include <frontend_manager/frontend.hpp>
+#include <frontend_manager/input_model.hpp>
 #include <tensorflow_frontend/model.hpp>
 #include <tensorflow_frontend/utility.hpp>
 
-using namespace ngraph::frontend;
-
-namespace tensorflow {
-class GraphDef;
-class NodeDef;
-namespace ngraph_bridge {
-class GraphIteratorProto;
-}
-}  // namespace tensorflow
+using namespace ::ngraph::frontend;
 
 namespace ngraph {
 namespace frontend {
@@ -61,8 +54,14 @@ protected:
     bool supported_impl(const std::vector<std::shared_ptr<Variant>>& variants) const override;
 
     InputModel::Ptr load_impl(const std::vector<std::shared_ptr<Variant>>& variants) const override;
+
+private:
+    static void translate_graph(const std::shared_ptr<InputModelTF>& model,
+                         const std::string model_name,
+                         bool fail_fast,
+                         bool no_conversion,
+                         std::shared_ptr<ngraph::Function>& ng_function);
 };
 
 }  // namespace frontend
-
 }  // namespace ngraph

--- a/ngraph/frontend/tensorflow/include/tensorflow_frontend/graph_iterator.hpp
+++ b/ngraph/frontend/tensorflow/include/tensorflow_frontend/graph_iterator.hpp
@@ -11,6 +11,8 @@ namespace frontend {
 /// Abstract representation for an input model graph that gives nodes in topologically sorted order
 class GraphIterator {
 public:
+    typedef std::shared_ptr<GraphIterator> Ptr;
+
     /// \brief Get a number of operation nodes in the graph
     virtual size_t size() const = 0;
 

--- a/ngraph/frontend/tensorflow/include/tensorflow_frontend/model.hpp
+++ b/ngraph/frontend/tensorflow/include/tensorflow_frontend/model.hpp
@@ -6,6 +6,7 @@
 
 #include <frontend_manager/input_model.hpp>
 #include <frontend_manager/place.hpp>
+#include <tensorflow_frontend/graph_iterator.hpp>
 #include <tensorflow_frontend/utility.hpp>
 
 namespace ngraph {
@@ -19,17 +20,11 @@ class TF_API InputModelTF : public InputModel {
     class InputModelTFImpl;
     std::shared_ptr<InputModelTFImpl> _impl;
 
-public:
-    // TODO: move to private once GraphTranslation will be a part of FrontEndTF component
     std::vector<std::shared_ptr<OpPlaceTF>> get_op_places() const;
     std::map<std::string, std::shared_ptr<TensorPlaceTF>> get_tensor_places() const;
     std::map<std::string, Output<Node>> get_tensor_values() const;
-
-    explicit InputModelTF(const std::string& path);
-#if defined(ENABLE_UNICODE_PATH_SUPPORT) && defined(_WIN32)
-    explicit InputModelTF(const std::wstring& path);
-#endif
-    explicit InputModelTF(const std::vector<std::istream*>& streams);
+public:
+    explicit InputModelTF(const GraphIterator::Ptr& graph_iterator);
 
     std::vector<Place::Ptr> get_inputs() const override;
     std::vector<Place::Ptr> get_outputs() const override;

--- a/ngraph/frontend/tensorflow/include/tensorflow_frontend/model.hpp
+++ b/ngraph/frontend/tensorflow/include/tensorflow_frontend/model.hpp
@@ -23,6 +23,7 @@ class TF_API InputModelTF : public InputModel {
     std::vector<std::shared_ptr<OpPlaceTF>> get_op_places() const;
     std::map<std::string, std::shared_ptr<TensorPlaceTF>> get_tensor_places() const;
     std::map<std::string, Output<Node>> get_tensor_values() const;
+
 public:
     explicit InputModelTF(const GraphIterator::Ptr& graph_iterator);
 

--- a/ngraph/frontend/tensorflow/src/frontend.cpp
+++ b/ngraph/frontend/tensorflow/src/frontend.cpp
@@ -302,7 +302,7 @@ InputModel::Ptr FrontEndTF::load_impl(const std::vector<std::shared_ptr<Variant>
         if (ov::is_type<VariantWrapper<std::string>>(variants[0])) {
             std::string suffix = ".pb";
             std::string model_path = ov::as_type_ptr<VariantWrapper<std::string>>(variants[0])->get();
-            if (tf::endsWith(model_path, suffix)) {
+            if (ov::util::ends_with(model_path, suffix)) {
                 return std::make_shared<InputModelTF>(
                     std::make_shared<::ngraph::frontend::tf::GraphIteratorProto>(model_path));
             }

--- a/ngraph/frontend/tensorflow/src/frontend.cpp
+++ b/ngraph/frontend/tensorflow/src/frontend.cpp
@@ -11,20 +11,45 @@
 #include "op_table.hpp"
 #include "tf_framework_node.hpp"
 
-using namespace google;
-
-using namespace ngraph::frontend;
-using namespace ngraph::frontend::tf;
+using namespace ::ngraph::frontend;
+using namespace ::ngraph::frontend::tf;
 using namespace ::tensorflow::ngraph_bridge;
 
-using ::tensorflow::GraphDef;
-
 namespace {
-void TranslateGraph(const std::shared_ptr<ngraph::frontend::InputModelTF>& model,
-                    const std::string model_name,
-                    bool fail_fast,
-                    bool no_conversion,
-                    std::shared_ptr<ngraph::Function>& ng_function) {
+void TranslateFWNode(const std::shared_ptr<TFFrameworkNode>& node) {
+    auto type = node->get_op_type();
+
+    const auto TRANSLATE_OP_MAP = get_supported_ops();
+    auto translator_it = TRANSLATE_OP_MAP.find(type);
+    FRONT_END_OP_CONVERSION_CHECK(translator_it != TRANSLATE_OP_MAP.end(), "No translator found for ", type, " node.");
+
+    ngraph::OutputVector ng_inputs;
+    NamedInputs named_inputs;
+    size_t input_port_idx = 0;
+    for (auto& input : node->inputs()) {
+        ng_inputs.push_back(input.get_source_output());
+        named_inputs[input_port_idx++] = {input.get_source_output()};
+    }
+
+    NodeContext node_ctx(*node->get_decoder(), named_inputs);
+    auto new_node_outputs = translator_it->second(node_ctx);
+    SetTracingInfo(node_ctx.get_name(), new_node_outputs.front());
+
+    auto new_output = new_node_outputs.begin();
+    auto old_outputs = node->outputs();
+    auto old_output = old_outputs.begin();
+
+    for (; new_output != new_node_outputs.end() && old_output != old_outputs.end(); ++old_output, ++new_output) {
+        old_output->replace(*new_output);
+    }
+}
+}  // namespace
+
+void FrontEndTF::translate_graph(const std::shared_ptr<InputModelTF>& model,
+                                 const std::string model_name,
+                                 bool fail_fast,
+                                 bool no_conversion,
+                                 std::shared_ptr<ngraph::Function>& ng_function) {
     using OpMap = std::unordered_map<std::string, std::vector<ngraph::Output<ngraph::Node>>>;
     // a map from operation names to generated nGraph Output<TFNodeDecoder>
     OpMap ng_op_map;
@@ -252,39 +277,10 @@ void TranslateGraph(const std::shared_ptr<ngraph::frontend::InputModelTF>& model
     NGRAPH_VLOG(5) << "Done with translations";
 }
 
-void TranslateFWNode(const std::shared_ptr<TFFrameworkNode>& node) {
-    auto type = node->get_op_type();
-
-    const auto TRANSLATE_OP_MAP = get_supported_ops();
-    auto translator_it = TRANSLATE_OP_MAP.find(type);
-    FRONT_END_OP_CONVERSION_CHECK(translator_it != TRANSLATE_OP_MAP.end(), "No translator found for ", type, " node.");
-
-    ngraph::OutputVector ng_inputs;
-    NamedInputs named_inputs;
-    size_t input_port_idx = 0;
-    for (auto& input : node->inputs()) {
-        ng_inputs.push_back(input.get_source_output());
-        named_inputs[input_port_idx++] = {input.get_source_output()};
-    }
-
-    NodeContext node_ctx(*node->get_decoder(), named_inputs);
-    auto new_node_outputs = translator_it->second(node_ctx);
-    SetTracingInfo(node_ctx.get_name(), new_node_outputs.front());
-
-    auto new_output = new_node_outputs.begin();
-    auto old_outputs = node->outputs();
-    auto old_output = old_outputs.begin();
-
-    for (; new_output != new_node_outputs.end() && old_output != old_outputs.end(); ++old_output, ++new_output) {
-        old_output->replace(*new_output);
-    }
-}
-}  // namespace
-
 /// \brief Check if FrontEndTensorflow can recognize model from given parts
 bool FrontEndTF::supported_impl(const std::vector<std::shared_ptr<Variant>>& variants) const {
-    // TODO: Support TensorFlow 2 SavedModel format
-    if (variants.empty() || variants.size() > 2)
+    // TODO: Support other TensorFlow formats: SavedModel, .meta, checkpoint, pbtxt
+    if (variants.size() != 1)
         return false;
 
     // Validating first path, it must contain a model
@@ -299,13 +295,16 @@ bool FrontEndTF::supported_impl(const std::vector<std::shared_ptr<Variant>>& var
 }
 
 InputModel::Ptr FrontEndTF::load_impl(const std::vector<std::shared_ptr<Variant>>& variants) const {
-    // TODO: convert any format variant to GraphIterator and pass it to the single constuctor
-    // InputModelTF with GraphIterator
+    // TODO: Support other TensorFlow formats: SavedModel, .meta, checkpoint, pbtxt
     if (variants.size() == 1) {
-        // a case when protobuf format or SavedModel dir format is provided
+        // a case when binary protobuf format is provided
         if (ov::is_type<VariantWrapper<std::string>>(variants[0])) {
-            std::string m_path = ov::as_type_ptr<VariantWrapper<std::string>>(variants[0])->get();
-            return std::make_shared<InputModelTF>(m_path);
+            std::string suffix = ".pb";
+            std::string model_path = ov::as_type_ptr<VariantWrapper<std::string>>(variants[0])->get();
+            if (tf::endsWith(model_path, suffix)) {
+                return std::make_shared<InputModelTF>(
+                    std::make_shared<::ngraph::frontend::tf::GraphIteratorProto>(model_path));
+            }
         }
     }
     return nullptr;
@@ -316,7 +315,7 @@ std::shared_ptr<ngraph::Function> FrontEndTF::convert(InputModel::Ptr model) con
     std::cout << "[ INFO ] FrontEndTensorflow::convert invoked\n";
 
     std::shared_ptr<ngraph::Function> f;
-    TranslateGraph(model_tf, "here_should_be_a_graph_name", true, false, f);
+    translate_graph(model_tf, "here_should_be_a_graph_name", true, false, f);
     std::cout << "[ STATUS ] TranslateGraph was called successfuly.\n";
     std::cout << "[ INFO ] Resulting nGraph function contains " << f->get_ops().size() << " nodes." << std::endl;
 
@@ -332,7 +331,7 @@ std::shared_ptr<ngraph::Function> FrontEndTF::convert_partially(InputModel::Ptr 
     std::cout << "[ INFO ] FrontEndTensorflow::convert_partially invoked\n";
 
     std::shared_ptr<ngraph::Function> f;
-    TranslateGraph(model_tf, "here_should_be_a_graph_name", false, false, f);
+    translate_graph(model_tf, "here_should_be_a_graph_name", false, false, f);
     std::cout << "[ STATUS ] TranslateGraph was called successfuly.\n";
     std::cout << "[ INFO ] Resulting nGraph function contains " << f->get_ops().size() << " nodes." << std::endl;
 
@@ -345,7 +344,7 @@ std::shared_ptr<ngraph::Function> FrontEndTF::decode(InputModel::Ptr model) cons
     std::cout << "[ INFO ] FrontEndTensorflow::decode invoked\n";
 
     std::shared_ptr<ngraph::Function> f;
-    TranslateGraph(model_tf, "here_should_be_a_graph_name", false, true, f);
+    translate_graph(model_tf, "here_should_be_a_graph_name", false, true, f);
     std::cout << "[ STATUS ] TranslateGraphFWNode was called successfuly.\n";
     std::cout << "[ INFO ] Resulting nGraph function contains " << f->get_ops().size() << " nodes." << std::endl;
     return f;

--- a/ngraph/frontend/tensorflow/src/frontend.cpp
+++ b/ngraph/frontend/tensorflow/src/frontend.cpp
@@ -27,7 +27,7 @@ void TranslateFWNode(const std::shared_ptr<TFFrameworkNode>& node) {
     ngraph::OutputVector ng_inputs;
     NamedInputs named_inputs;
     size_t input_port_idx = 0;
-    for (auto& input : node->inputs()) {
+    for (const auto& input : node->inputs()) {
         ng_inputs.push_back(input.get_source_output());
         named_inputs[input_port_idx++] = {input.get_source_output()};
     }
@@ -47,7 +47,7 @@ void TranslateFWNode(const std::shared_ptr<TFFrameworkNode>& node) {
 }  // namespace
 
 void FrontEndTF::translate_graph(const std::shared_ptr<InputModelTF>& model,
-                                 const std::string model_name,
+                                 const std::string& model_name,
                                  bool fail_fast,
                                  bool no_conversion,
                                  std::shared_ptr<ngraph::Function>& ng_function) {
@@ -302,7 +302,7 @@ InputModel::Ptr FrontEndTF::load_impl(const std::vector<std::shared_ptr<Variant>
         if (ov::is_type<VariantWrapper<std::string>>(variants[0])) {
             std::string suffix = ".pb";
             std::string model_path = ov::as_type_ptr<VariantWrapper<std::string>>(variants[0])->get();
-            if (ov::util::ends_with(model_path, suffix)) {
+            if (ov::util::ends_with(model_path, suffix.c_str())) {
                 return std::make_shared<InputModelTF>(
                     std::make_shared<::ngraph::frontend::tf::GraphIteratorProto>(model_path));
             }

--- a/ngraph/frontend/tensorflow/src/graph_iterator_proto.hpp
+++ b/ngraph/frontend/tensorflow/src/graph_iterator_proto.hpp
@@ -22,8 +22,7 @@ class GraphIteratorProto : public ::ngraph::frontend::GraphIterator {
 
 public:
     template <typename T>
-    GraphIteratorProto(const std::basic_string<T>& path)
-        : m_graph_def(std::make_shared<::tensorflow::GraphDef>()) {
+    GraphIteratorProto(const std::basic_string<T>& path) : m_graph_def(std::make_shared<::tensorflow::GraphDef>()) {
         std::ifstream pb_stream(path, std::ios::in | std::ifstream::binary);
 
         FRONT_END_GENERAL_CHECK(pb_stream && pb_stream.is_open(), "Model file does not exist");

--- a/ngraph/frontend/tensorflow/src/graph_iterator_proto.hpp
+++ b/ngraph/frontend/tensorflow/src/graph_iterator_proto.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <fstream>
 #include <tensorflow_frontend/decoder.hpp>
 #include <tensorflow_frontend/graph_iterator.hpp>
 
@@ -17,18 +18,20 @@ namespace tf {
 class GraphIteratorProto : public ::ngraph::frontend::GraphIterator {
     std::vector<const ::tensorflow::NodeDef*> m_nodes;
     size_t node_index = 0;
+    std::shared_ptr<::tensorflow::GraphDef> m_graph_def;
 
 public:
-    GraphIteratorProto(const ::tensorflow::GraphDef* _graph) {
-        m_nodes.resize(_graph->node_size());
-        for (size_t i = 0; i < m_nodes.size(); ++i)
-            m_nodes[i] = &_graph->node(i);
-    }
+    template <typename T>
+    GraphIteratorProto(const std::basic_string<T>& path)
+        : m_graph_def(std::make_shared<::tensorflow::GraphDef>()) {
+        std::ifstream pb_stream(path, std::ios::in | std::ifstream::binary);
 
-    GraphIteratorProto(const std::vector<std::shared_ptr<::tensorflow::NodeDef>>& _sorted_nodes) {
-        m_nodes.resize(_sorted_nodes.size());
+        FRONT_END_GENERAL_CHECK(pb_stream && pb_stream.is_open(), "Model file does not exist");
+        FRONT_END_GENERAL_CHECK(m_graph_def->ParseFromIstream(&pb_stream), "Model cannot be parsed");
+
+        m_nodes.resize(m_graph_def->node_size());
         for (size_t i = 0; i < m_nodes.size(); ++i)
-            m_nodes[i] = _sorted_nodes[i].get();
+            m_nodes[i] = &m_graph_def->node(i);
     }
 
     /// Set iterator to the start position

--- a/ngraph/frontend/tensorflow/src/model.cpp
+++ b/ngraph/frontend/tensorflow/src/model.cpp
@@ -211,7 +211,6 @@ InputModelTF::InputModelTFImpl::InputModelTFImpl(const GraphIterator::Ptr& graph
                                                  const InputModel& input_model)
     : m_input_model(input_model),
       m_graph_iterator(graph_iterator) {
-
     FRONT_END_GENERAL_CHECK(m_graph_iterator, "Null pointer specified for GraphIterator");
     loadPlaces();
 }

--- a/ngraph/frontend/tensorflow/src/utils.h
+++ b/ngraph/frontend/tensorflow/src/utils.h
@@ -417,7 +417,7 @@ static Status GetStaticInputNode(
 // should be (e.g. when T is `bool`, we actually need a std::vector of `char` for
 // compatibility with nGraph).
         template <typename T, typename VecT = T>
-        static Status ValuesFromConstNode(const DecoderBase* node,
+        static Status ValuesFromConstNode(const ::ngraph::frontend::DecoderBase* node,
                                           ngraph::Shape* const_tensor_shape,
                                           std::vector<VecT>* values) {
 #if 1


### PR DESCRIPTION
**Details**: 
- InputModelTF construction happens with GraphIterator only
- Different GraphIterator are responsible for different TensorFlow formats. Now we have only GraphIteratorProto responsible for binary protobuf format
- FrontEnd load method prepares GraphIterator for a given format
- all truly private methods (get_op_nodes, etc.) of InputModelTF are moved to private section after proper code-refactoring

**Ticket**: 62697